### PR TITLE
Change bit cost defaults to something sensible

### DIFF
--- a/Player Events/EventLookup.cs
+++ b/Player Events/EventLookup.cs
@@ -10,16 +10,16 @@ namespace TwitchInteraction.Player_Events
 
         //MAP OF FUNZONE AND DANGER ZONE KEYS TO THEIR APPROPRIATE FUNCTIONS
         private static readonly Dictionary<string, EventInfo> EventDictionary = new Dictionary<string, EventInfo>(){
-            { "Rip Riley [Integration]", new EventInfo(DangerZone.KillPlayer, 200)},
-            { "Heal Riley [Integration]", new EventInfo(FunZone.HealPlayer, 10) },
-            { "Toggle Day/Night [Integration]", new EventInfo(FunZone.ToggleDayNight, 5) },
-            { "Open PDA [Integration]", new EventInfo(FunZone.openPDA, 5) },
+            { "Rip Riley [Integration]", new EventInfo(DangerZone.KillPlayer, 300)},
+            { "Heal Riley [Integration]", new EventInfo(FunZone.HealPlayer, 50) },
+            { "Toggle Day/Night [Integration]", new EventInfo(FunZone.ToggleDayNight, 50) },
+            { "Open PDA [Integration]", new EventInfo(FunZone.openPDA, 50) },
             { "Turn on the big gun [Integration]", new EventInfo(DangerZone.EnableGun, 50) },
-            { "Fill Oxygen [Integration]", new EventInfo(FunZone.FillOxygen, 5) },
-            { "Random Mouse Sensitivity [Integration]", new EventInfo(FunZone.RandomMouseSens, 5) },
-            { "Hide HUD [Integration]", new EventInfo(FunZone.hideHUD, 10) },
-            { "Show HUD [Integration]", new EventInfo(FunZone.showHUD, 10) },
-            { "Find a new home [Integration]", new EventInfo(FunZone.LifePodWarp_Shallows, 10) }
+            { "Fill Oxygen [Integration]", new EventInfo(FunZone.FillOxygen, 50) },
+            { "Random Mouse Sensitivity [Integration]", new EventInfo(FunZone.RandomMouseSens, 100) },
+            { "Hide HUD [Integration]", new EventInfo(FunZone.hideHUD, 50) },
+            { "Show HUD [Integration]", new EventInfo(FunZone.showHUD, 50) },
+            { "Find a new home [Integration]", new EventInfo(FunZone.LifePodWarp_Shallows, 100) }
         };
 
         public static string getBitCosts()


### PR DESCRIPTION
I also propose a 40x conversion rate between bits and channel points such that killing ryley costs 12000 points and changing it to day/night costs 2000 points