### PR TITLE
Events for inverting & disabling controls

### DIFF
--- a/Input/InputPatch.cs
+++ b/Input/InputPatch.cs
@@ -1,0 +1,157 @@
+using HarmonyLib;
+using TwitchInteraction.Player_Events;
+using UnityEngine;
+
+namespace TwitchInteraction.InputPatch
+{
+
+    public class InputPatch
+    {
+        public static bool invertKeyboardAxisX = false, invertKeyboardAxisY = false, invertKeyboardAxisZ = false;
+        public static bool invertMouseAxisX = false, invertMouseAxisY = false;
+        public static bool controlsEnabled = true;
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetMoveDirection")]
+    internal class KeyboardAxisPatch
+    {
+
+        [HarmonyPostfix]
+        public static void Postfix(ref Vector3 __result)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = Vector3.zero;
+            }
+
+            if (InputPatch.invertKeyboardAxisX)
+            {
+                __result.x *= -1;
+            }
+            if (InputPatch.invertKeyboardAxisY)
+            {
+                __result.y *= -1;
+            }
+            if (InputPatch.invertKeyboardAxisZ)
+            {
+                __result.z *= -1;
+            }
+        }
+
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetLookDelta")]
+    internal class MouseAxisPatch
+    {
+
+        [HarmonyPostfix]
+        public static void Postfix(ref Vector2 __result)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = Vector2.zero;
+            }
+
+            if (InputPatch.invertMouseAxisX)
+            {
+                __result.x *= -1;
+            }
+            if (InputPatch.invertMouseAxisY)
+            {
+                __result.y *= -1;
+            }
+        }
+
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetAnalogValueForButton")]
+    internal class AnalogValue_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref float __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = 0;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetInputStateForButton")]
+    internal class InputState_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref GameInput.InputState __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = new GameInput.InputState
+                {
+                    flags = GameInput.InputStateFlags.Up,
+                    timeDown = 0f
+                };
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetButtonDown")]
+    internal class ButtonDown_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref bool __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = false;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetButtonHeld")]
+    internal class ButtonHeld_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref bool __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = false;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetButtonUp")]
+    internal class ButtonUp_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref bool __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = true;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch("GetButtonHeldTime")]
+    internal class ButtonTime_Patch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref float __result, GameInput.Button button)
+        {
+            if (!InputPatch.controlsEnabled)
+            {
+                __result = 0;
+            }
+        }
+    }
+
+}

--- a/Player Events/EventLookup.cs
+++ b/Player Events/EventLookup.cs
@@ -25,7 +25,9 @@ namespace TwitchInteraction.Player_Events
             { "Cow or Reaper? Yes. [Integration]", new EventInfo(FunZone.randomSummon, 100) },
             { "Fill him up with junk [Integration]", new EventInfo(FunZone.junkFill, 50) },
             { "Get your pet reaper to hang out [Integration]", new EventInfo(DangerZone.summonReaper, 150) },
-            { "Resource Roulette [Integration]", new EventInfo(FunZone.randomItem, 100) }
+            { "Resource Roulette [Integration]", new EventInfo(FunZone.randomItem, 100) },
+            { "Invert Controls [Integration]", new EventInfo(FunZone.InvertControls, 200) },
+            { "Disable Controls [Integration]", new EventInfo(FunZone.DisableControls, 100) }
         };
 
         public static string getBitCosts()

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using UnityEngine;
+using TwitchInteraction.InputPatch;
 
 namespace TwitchInteraction.Player_Events
 {
@@ -46,18 +47,35 @@ namespace TwitchInteraction.Player_Events
             Player.main.oxygenMgr.AddOxygen(Player.main.GetOxygenAvailable() + 3);            
         }
 
+        private static float initialMouseSens;
+        private static Timer randomMouseSensTimer;
+        private static bool randomMouseSensTimerRunning = false;
+
         public static void RandomMouseSens()
         {
 
-            float currentSens = GameInput.GetMouseSensitivity();
-            System.Random random = new System.Random();
-            GameInput.SetMouseSensitivity((float)random.NextDouble());
-
-            var timer = new Timer(async (e) =>
+            if (!randomMouseSensTimerRunning)
             {
-                GameInput.SetMouseSensitivity(currentSens);
-            }, null, TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+                // Only update this when there is no timer running
+                initialMouseSens = GameInput.GetMouseSensitivity();
+            }
 
+            System.Random random = new System.Random();
+            GameInput.SetMouseSensitivity((float) random.NextDouble());
+
+            if (randomMouseSensTimerRunning)
+            {
+                // Stop the timer and immediately apply the next effect to prevent overlaps
+                randomMouseSensTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                randomMouseSensTimer.Dispose();
+            }
+
+            randomMouseSensTimer = new Timer(async (e) =>
+            {
+                GameInput.SetMouseSensitivity(initialMouseSens);
+                randomMouseSensTimerRunning = false;
+            }, null, TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            randomMouseSensTimerRunning = true;
         }
 
         public static void hideHUD()
@@ -108,6 +126,58 @@ namespace TwitchInteraction.Player_Events
             {
                 CraftData.AddToInventory(listofstuff[random.Next(listofstuff.Length)], 1, false, false);
             }
+        }
+
+        private static Timer invertControlsTimer;
+        private static bool invertControlsTimerRunning = false;
+
+        public static void InvertControls()
+        {
+            InputPatch.InputPatch.invertKeyboardAxisX = true;
+            InputPatch.InputPatch.invertKeyboardAxisY = true;
+            InputPatch.InputPatch.invertKeyboardAxisZ = true;
+            InputPatch.InputPatch.invertMouseAxisX = true;
+            InputPatch.InputPatch.invertMouseAxisY = true;
+
+            if (invertControlsTimerRunning)
+            {
+                // Stop the timer and immediately apply the next effect to prevent overlaps
+                invertControlsTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                invertControlsTimer.Dispose();
+            }
+
+            invertControlsTimer = new Timer(async (e) =>
+            {
+                InputPatch.InputPatch.invertKeyboardAxisX = false;
+                InputPatch.InputPatch.invertKeyboardAxisY = false;
+                InputPatch.InputPatch.invertKeyboardAxisZ = false;
+                InputPatch.InputPatch.invertMouseAxisX = false;
+                InputPatch.InputPatch.invertMouseAxisY = false;
+                invertControlsTimerRunning = false;
+            }, null, TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            invertControlsTimerRunning = true;
+        }
+
+        private static Timer disableControlsTimer;
+        private static bool disableControlsTimerRunning = false;
+
+        public static void DisableControls()
+        {
+            InputPatch.InputPatch.controlsEnabled = false;
+
+            if (disableControlsTimerRunning)
+            {
+                // Stop the timer and immediately apply the next effect to prevent overlaps
+                disableControlsTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                disableControlsTimer.Dispose();
+            }
+
+            disableControlsTimer = new Timer(async (e) =>
+            {
+                InputPatch.InputPatch.controlsEnabled = true;
+                disableControlsTimerRunning = false;
+            }, null, TimeSpan.FromSeconds(10), Timeout.InfiniteTimeSpan);
+            disableControlsTimerRunning = true;
         }
 
     }


### PR DESCRIPTION
I set up Harmony and the QModManager using [this link](https://bitbucket.org/glibfire/subnauticamods/src/master/ModdingTutorial/ModdingTutorial.md), the dll I use is located under `%SUBNAUTICA%/BepInEx/core/0Harmony.dll`.

Also, we should probably switch to a publicised `Assembly-CSharp.dll`. The explanation how to do this can be found [here](https://github.com/MrPurple6411/AssemblyPublicizer), and [this](https://github.com/MrPurple6411/AssemblyPublicizer/archive/v1.1.0.zip) is the latest release of the tool. Once it's set up in the dev environment, we can access private fields of the `Assembly-CSharp.dll`. It even works with the original `Assembly-CSharp.dll` that Subnautica uses, so this is a dev environment only thing.

Alternatively the `InputState_Patch` class in the `Input/InputPatch.cs` file can be deleted. It might mess with the disabled controls, depending on how much Subnautica uses that method. I prefer the publicised assembly as we might very well need to access private fields again at some point.