### PR TITLE
Adding one hit knockout effect

### DIFF
--- a/Config.txt.template
+++ b/Config.txt.template
@@ -37,6 +37,7 @@
         { "event": "Disable Controls [Integration]", "bit_cost": 200, "cooldown": 60 },
         { "event": "Light? What is light? [Integration]", "bit_cost": 100, "cooldown": 60 },
         { "event": "Random FOV [Integration]", "bit_cost": 1000, "cooldown": 60 },
-        { "event": "What explosion? [Integration]", "bit_cost": 30, "cooldown": 30 }	
+        { "event": "What explosion? [Integration]", "bit_cost": 30, "cooldown": 30 },
+		{ "event": "Be careful Riley [Integration]", "bit_cost": 500, "cooldown": 60 }
 	]	
 }

--- a/CrowdControlEventManager.cs
+++ b/CrowdControlEventManager.cs
@@ -42,7 +42,8 @@ namespace TwitchInteraction
             { "disable_controls", "Disable Controls [Integration]" },
             { "filmic_mode", "Light? What is light? [Integration]" },
             { "random_fov", "Random FOV [Integration]" },
-            { "restore_ship", "What explosion? [Integration]"  }
+            { "restore_ship", "What explosion? [Integration]"  },
+            { "ohko", "Be careful Riley [Integration]" }
         };
 
         internal static void MessageReceived(int sender, string message)

--- a/Player Events/DangerZone.cs
+++ b/Player Events/DangerZone.cs
@@ -118,5 +118,15 @@ namespace TwitchInteraction.Player_Events
             EscapePod.main.transform.position = spawnPosition;
             EscapePod.main.anchorPosition = spawnPosition;
         }
+
+        public static void ActivateOHKO()
+        {
+            OneHitKnockout.active = true;
+        }
+
+        public static void DeactiveOHKO()
+        {
+            OneHitKnockout.active = false;
+        }
     }
 }

--- a/Player Events/EventLookup.cs
+++ b/Player Events/EventLookup.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using TwitchInteraction.Player_Events.Models;
-using System.Collections.Concurrent;
 
 namespace TwitchInteraction.Player_Events
 {
@@ -55,7 +54,8 @@ namespace TwitchInteraction.Player_Events
             { "Invert Controls [Integration]", new TimedEventInfo(FunZone.InvertControls, 200, 60, FunZone.NormalControls, 60) },
             { "Disable Controls [Integration]", new TimedEventInfo(FunZone.DisableControls, 200, 60, FunZone.EnableControls, 10) },
             { "Light? What is light? [Integration]", new TimedEventInfo(FunZone.EnableFilmicMode, 100, 60, FunZone.DisableFilmicMode, 60) },
-            { "Random FOV [Integration]", new TimedEventInfo(FunZone.fovRandom, 1000, 60, FunZone.fovNormal, 60) }
+            { "Random FOV [Integration]", new TimedEventInfo(FunZone.fovRandom, 1000, 60, FunZone.fovNormal, 60) },
+            { "Be careful Riley [Integration]", new TimedEventInfo(DangerZone.ActivateOHKO, 500, 60, DangerZone.DeactiveOHKO, 60) }
         };
 
         public static string getBitCosts()

--- a/Player Events/LiveMixinPatcher.cs
+++ b/Player Events/LiveMixinPatcher.cs
@@ -1,0 +1,44 @@
+using HarmonyLib;
+using System;
+
+namespace TwitchInteraction.Player_Events
+{
+    public class OneHitKnockout {
+        public static bool active = false;
+    }
+
+    [HarmonyPatch(typeof(LiveMixin))]
+    [HarmonyPatch("TakeDamage")]
+    internal class LiveMixin_TakeDamage_Patch
+    {
+        [HarmonyPrefix]
+        static bool Prefix(ref LiveMixin __instance, ref bool __result)
+        {
+            if((Object)__instance.gameObject.GetComponent<Player>() == (Object)null)
+            {
+                // Not the player taking damage, execute the function normally
+                return true;
+            }
+            
+            // Check if OHKO flag is active
+            if (OneHitKnockout.active)
+            {
+                // Reuse the kill logic from the LiveMixin, to ensure that cutscenes are handled properly.
+                __result = true;
+                if (!__instance.IsCinematicActive())
+                {
+                    __instance.Kill();
+                }
+                else
+                {
+                    __instance.cinematicModeActive = true;
+                    __instance.SyncUpdatingState();
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/SubCrowdControl.cs
+++ b/SubCrowdControl.cs
@@ -46,6 +46,7 @@ public class Subnautica : SimpleTCPPack
         new Effect("Invert Controls (60 seconds)", "invert_controls"),
         new Effect("Disable Controls (10 seconds)", "disable_controls"),
         new Effect("Light? What is light? (60 seconds)", "filmic_mode"),
-        new Effect("Random FOV (60 seconds)", "random_fov")
+        new Effect("Random FOV (60 seconds)", "random_fov"),
+        new Effect("Be careful Riley (60 seconds)", "ohko")
     };
 }

--- a/TwitchInteraction.csproj
+++ b/TwitchInteraction.csproj
@@ -287,6 +287,7 @@
   <ItemGroup>
     <Compile Include="Input\InputPatch.cs" />
     <Compile Include="Player Events\HUDHandler.cs" />
+	<Compile Include="Player Events\LiveMixinPatcher.cs" />
     <Compile Include="Player Events\Models\EventInfo.cs" />
     <Compile Include="Player Events\EventLookup.cs" />
     <Compile Include="Player Events\FunZone.cs" />


### PR DESCRIPTION
Adding a harmony patch to the LiveMixin, which checks to see if it is the player taking damage and if the OHKO effect is active. If it is, it executes a kill event on the player and skips the base TakeDamage function. Otherwise TakeDamage is executed normally. Added the effect to the DangerZone and on all the various effect lists. Tested it locally using the CrowdControlSDK (both player damage normal, OHKO active, and other creature damage).