### PR TITLE
Removing event queue when using CC. Adding CC test event handling

### DIFF
--- a/CrowdControlEventManager.cs
+++ b/CrowdControlEventManager.cs
@@ -72,11 +72,30 @@ namespace TwitchInteraction
                 var eventName = EventNameDict[request.Code];
                 var status = 0;
 
+                if (request.Id == 0 && request.Type == 255)
+                {
+                    // Test message, ignore
+                    return;
+                }
+
                 if (TimerCooldown.IsInitialised())
                 {
                     try
                     {
-                        EventLookup.Lookup(eventName, request.Viewer);
+                        // Check to see if the event can fire currently fire, or is on cooldown.
+                        if (!EventLookup.IsRunningOrCooldown(eventName))
+                        {
+                            // Not running or on cooldown, activate it if the type is "start"
+                            if (request.Type == 1)
+                            {
+                                EventLookup.Lookup(eventName, request.Viewer);
+                            }                            
+                        }
+                        else
+                        {
+                            // Event in use, retry.
+                            status = 3;
+                        }
                     }
                     catch (Exception)
                     {

--- a/Player Events/EventLookup.cs
+++ b/Player Events/EventLookup.cs
@@ -78,6 +78,11 @@ namespace TwitchInteraction.Player_Events
             }
         }
 
+        public static Boolean IsRunningOrCooldown(string Key)
+        {
+            return (RunningEventIDs.Contains(Key) || Cooldowns.ContainsKey(Key));
+        }
+
         public static void Lookup(string EventText, string User, int bits)
         {
             KeyValuePair<string, EventInfo> Event = EventDictionary.FirstOrDefault(it => EventText.Contains(it.Key));

--- a/Player Events/PlayerPatcher.cs
+++ b/Player Events/PlayerPatcher.cs
@@ -34,13 +34,12 @@ namespace TwitchInteraction.Player_Events
                     for (int i = 0; i < EventLookup.ActionQueue.Count; i++)
                     {
                         KeyValuePair<string, EventInfo> keyValuePair = EventLookup.ActionQueue[i];
-                        if (EventLookup.RunningEventIDs.Contains(keyValuePair.Key) || EventLookup.Cooldowns.ContainsKey(keyValuePair.Key))
+                        if (!EventLookup.IsRunningOrCooldown(keyValuePair.Key))
                         {
-                            continue;
+                            // Safe to use, doesnt have cooldown / is currently in use
+                            localEventInfo = keyValuePair;
+                            eventIndex = i;
                         }
-                        // Safe to use, doesnt have cooldown / is currently in use
-                        localEventInfo = keyValuePair;
-                        eventIndex = i;
                     }
 
                     if (eventIndex >= 0)


### PR DESCRIPTION
Talking with the CrowdControl devs, and they have features such as event queue management and refunds handled by their server. So having our own queue of events internal to the mod means these features don't work as well. This change checks to see if an event would queue, and if it does sends a message to CrowdControl to queue it rather than adding it to our own. 

This will only impact events that are triggered by CrowdControl, the Twitch client remains unchanged.

I also added code to handle test events and a quasi-heartbeat message that CrowdControl might send. 