### PR TITLE
Functionality tweaks

### DIFF
--- a/Player Events/DangerZone.cs
+++ b/Player Events/DangerZone.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using Random = UnityEngine.Random;
+using UWE;
 
 namespace TwitchInteraction.Player_Events
 {
@@ -74,6 +76,11 @@ namespace TwitchInteraction.Player_Events
 
         public static void TeleportPlayer()
         {
+            CoroutineHost.StartCoroutine(TeleportPlayerAsync());
+        }
+        
+        private static IEnumerator TeleportPlayerAsync()
+        {
             var biomeTeleportData = BiomeConsoleCommand.main.data;
             var locationTeleportData = GotoConsoleCommand.main.data;
 
@@ -89,6 +96,9 @@ namespace TwitchInteraction.Player_Events
             {
                 newPositionData = locationTeleportData.locations[newPositionNum - biomeTeleportData.locations.Length];
             }
+            
+            // queue the teleport until the player is not dead and not in a cinematic and not piloting and the game is not paused.
+            yield return new WaitUntil(() => Player.main.IsAlive() && !Player.main.cinematicModeActive && !Player.main.isPiloting && Time.timeScale > 0f);
 
             Player.main.SetPosition(newPositionData.position);
             Player.main.OnPlayerPositionCheat();

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -125,7 +125,9 @@ namespace TwitchInteraction.Player_Events
             if (CraftData.IsAllowed(blueprintTech[randomNum]) && KnownTech.Add(blueprintTech[randomNum], true))
             {
                 ErrorMessage.AddDebug("Unlocked " + Language.main.Get(blueprintTech[randomNum].AsString(false)));
+                return;
             }
+            CraftData.AddToInventory(TechType.Titanium, 2);
         }
 
         public static void randomItem()

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -135,7 +135,7 @@ namespace TwitchInteraction.Player_Events
             System.Random random = new System.Random();
             TechType[] resources = { TechType.AcidMushroom, TechType.SeaTreaderPoop, TechType.BloodOil, TechType.CoralChunk, TechType.CrashPowder, TechType.Copper, TechType.CreepvinePiece, TechType.CreepvineSeedCluster, TechType.Sulphur, TechType.WhiteMushroom, TechType.Diamond, TechType.TreeMushroomPiece, TechType.GasPod, TechType.JellyPlant, TechType.Gold, TechType.Kyanite, TechType.Lead, TechType.Lithium, TechType.Magnetite, TechType.ScrapMetal, TechType.Nickel, TechType.PinkMushroom, TechType.Quartz, TechType.AluminumOxide, TechType.Salt, TechType.Silver, TechType.SmallMelon, TechType.PurpleRattle, TechType.StalkerTooth, TechType.JeweledDiskPiece, TechType.Titanium, TechType.UraniniteCrystal };
             
-            var pickupable = CraftData.GetPrefabForTechType(resources[random.Next(resources.Length)]).GetComponent<Pickupable>();
+            var pickupable = CraftData.InstantiateFromPrefab(resources[random.Next(resources.Length)]).GetComponent<Pickupable>();
             if (pickupable != null)
                 Inventory.main.ForcePickup(pickupable);
         }

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -125,9 +125,9 @@ namespace TwitchInteraction.Player_Events
             if (CraftData.IsAllowed(blueprintTech[randomNum]) && KnownTech.Add(blueprintTech[randomNum], true))
             {
                 ErrorMessage.AddDebug("Unlocked " + Language.main.Get(blueprintTech[randomNum].AsString(false)));
-                return;
             }
-            CraftData.AddToInventory(TechType.Titanium, 2);
+            else
+                CraftData.AddToInventory(TechType.Titanium, 2);
         }
 
         public static void randomItem()

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UWE;
 
 namespace TwitchInteraction.Player_Events
 {
@@ -258,6 +260,13 @@ namespace TwitchInteraction.Player_Events
 
         public static void returnToShallows()
         {
+            CoroutineHost.StartCoroutine(ReturnToShallowsAsync());
+        }
+        
+        private static IEnumerator ReturnToShallowsAsync()
+        {
+            yield return new WaitUntil(() => !Player.main.isPiloting && !Player.main.cinematicModeActive);
+            
             EscapePod.main.RespawnPlayer();
         }
 

--- a/Player Events/FunZone.cs
+++ b/Player Events/FunZone.cs
@@ -131,9 +131,11 @@ namespace TwitchInteraction.Player_Events
         public static void randomItem()
         {
             System.Random random = new System.Random();
-            string[] resources = { "acidmushroom", "seatreaderpoop", "bloodoil", "coralchunk", "crashpowder", "copper", "creepvinepiece", "creepvineseedcluster", "sulphur", "whitemushroom", "diamond", "treemushroompiece", "gaspod", "jellyplant", "gold", "kyanite", "lead", "lithium", "magnetite", "scrapmetal", "nickel", "pinkmushroom", "quartz", "aluminumoxide", "salt", "silver", "smallmelon", "purplerattle", "stalkertooth", "jeweleddiskpiece", "titanium", "uraninitecrystal" };
-
-            DevConsole.SendConsoleCommand("item " + resources[random.Next(resources.Length)]);
+            TechType[] resources = { TechType.AcidMushroom, TechType.SeaTreaderPoop, TechType.BloodOil, TechType.CoralChunk, TechType.CrashPowder, TechType.Copper, TechType.CreepvinePiece, TechType.CreepvineSeedCluster, TechType.Sulphur, TechType.WhiteMushroom, TechType.Diamond, TechType.TreeMushroomPiece, TechType.GasPod, TechType.JellyPlant, TechType.Gold, TechType.Kyanite, TechType.Lead, TechType.Lithium, TechType.Magnetite, TechType.ScrapMetal, TechType.Nickel, TechType.PinkMushroom, TechType.Quartz, TechType.AluminumOxide, TechType.Salt, TechType.Silver, TechType.SmallMelon, TechType.PurpleRattle, TechType.StalkerTooth, TechType.JeweledDiskPiece, TechType.Titanium, TechType.UraniniteCrystal };
+            
+            var pickupable = CraftData.GetPrefabForTechType(resources[random.Next(resources.Length)]).GetComponent<Pickupable>();
+            if (pickupable != null)
+                Inventory.main.ForcePickup(pickupable);
         }
 
         public static void randomAdvancedResources()


### PR DESCRIPTION
## Changes made in this PR:
- made the Resource Roulette queue up the item if the inventory is full.
- made the Blueprint Rouletter spawn 2 titaniums if all of the blueprint are already acquired.
- made the PlayerTeleport queue up.