### PR TITLE
Fixing check for bit event text to ignore case

### DIFF
--- a/Player Events/EventLookup.cs
+++ b/Player Events/EventLookup.cs
@@ -85,7 +85,7 @@ namespace TwitchInteraction.Player_Events
 
         public static void Lookup(string EventText, string User, int bits)
         {
-            KeyValuePair<string, EventInfo> Event = EventDictionary.FirstOrDefault(it => EventText.Contains(it.Key));
+            KeyValuePair<string, EventInfo> Event = EventDictionary.FirstOrDefault(it => EventText.IndexOf(it.Key, StringComparison.OrdinalIgnoreCase) >= 0);
             Console.WriteLine(Event.Key);
             if (!Event.Equals(default(KeyValuePair<string, EventInfo>)) && bits >= Event.Value.BitCost)
             {


### PR DESCRIPTION
Have to use indexOf since in Contains doesn't take in a StringComparison. Also I can't test out this on my account, so it should be verified before we release it.